### PR TITLE
안드로이드 스튜디오 앱 수준 gradle 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,14 +3,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    signingConfigs {
-        release {
-            keyAlias 'releasekey'
-            keyPassword 'sjdmlgPxordms'
-            storeFile file('C:/Android_Avd_Gradle/.android/release.jks')
-            storePassword 'sjdmlgPxordms'
-        }
-    }
     compileSdkVersion 29
     buildToolsVersion "30.0.1"
 
@@ -26,7 +18,6 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
         }
     }
     compileOptions {


### PR DESCRIPTION
카카오 로그인 api 릴리즈 키를 찾아가기 위한 경로 필요없어서 삭제
- 콘솔 등록 이후 base64로 얻은 해시키를 카카오 디벨로퍼에 등록하면 해결되는 문제이기 때문